### PR TITLE
Add support for next.config.mjs, allow missing next.config file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugpilot/wizard",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Bugpilot Wizard is a CLI tool to help you setup Bugpilot in your project",
   "repository": {
     "type": "git",

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -128,10 +128,12 @@ export async function install(argv: Arguments<Args>) {
 
     outro(chalk.bold.green("Have an awesome day! Happy coding 🚀"));
 
-    await setTimeout(3 * 1000);
-    await open(
-      `https://app.bugpilot.com/workspace/${workspaceId}/overview?via=cli-done`,
-    );
+    if (process.env.NODE_ENV !== "development") {
+      await setTimeout(3 * 1000);
+      await open(
+        `https://app.bugpilot.com/workspace/${workspaceId}/overview?via=cli-done`,
+      );
+    }
   } catch (e) {
     if (e instanceof WizardError) {
       log.error(chalk.red(e.message));

--- a/src/nextjs/assertions.ts
+++ b/src/nextjs/assertions.ts
@@ -38,9 +38,7 @@ export function getNextJsConfigFilename() {
   const nextConfigPathMjs = path.join(cwd, "next.config.mjs");
 
   if (!fs.existsSync(nextConfigPathJs) && !fs.existsSync(nextConfigPathMjs)) {
-    throw new WizardError(
-      `next.config.js or next.config.mjs not found at ${nextConfigPathJs}. Please run this command from your project root directory.`,
-    );
+    return null;
   }
 
   return fs.existsSync(nextConfigPathJs) ? nextConfigPathJs : nextConfigPathMjs;

--- a/src/nextjs/assertions.ts
+++ b/src/nextjs/assertions.ts
@@ -33,12 +33,15 @@ export function ensureNextJsVersion() {
   }
 }
 
-export function ensureNextJsConfig() {
-  const nextConfigPath = path.join(cwd, "next.config.js");
+export function getNextJsConfigFilename() {
+  const nextConfigPathJs = path.join(cwd, "next.config.js");
+  const nextConfigPathMjs = path.join(cwd, "next.config.mjs");
 
-  if (!fs.existsSync(nextConfigPath)) {
+  if (!fs.existsSync(nextConfigPathJs) && !fs.existsSync(nextConfigPathMjs)) {
     throw new WizardError(
-      `next.config.js not found at ${nextConfigPath}. Please run this command from your project root directory.`,
+      `next.config.js or next.config.mjs not found at ${nextConfigPathJs}. Please run this command from your project root directory.`,
     );
   }
+
+  return fs.existsSync(nextConfigPathJs) ? nextConfigPathJs : nextConfigPathMjs;
 }

--- a/src/nextjs/babel-plugins/with-bugpilot-config.ts
+++ b/src/nextjs/babel-plugins/with-bugpilot-config.ts
@@ -1,7 +1,23 @@
-import { NodePath } from "@babel/core";
+import { NodePath, PluginObj, PluginOptions } from "@babel/core";
 import * as t from "@babel/types";
 
-export default function withBugpilotConfig() {
+type PluginOpts = PluginOptions & {
+  configFilePath: string;
+};
+
+const withBugpilotConfigFactory =
+  ({ configFilePath }: PluginOpts) =>
+  (): PluginObj => {
+    if (configFilePath.endsWith(".js") || configFilePath.endsWith(".cjs")) {
+      return cjsPlugin();
+    }
+
+    return esmPlugin();
+  };
+
+export default withBugpilotConfigFactory;
+
+function cjsPlugin(): PluginObj {
   return {
     visitor: {
       Program(path: NodePath<t.Program>) {
@@ -61,6 +77,78 @@ export default function withBugpilotConfig() {
 
           path.skip();
         }
+      },
+    },
+  };
+}
+
+function esmPlugin() {
+  return {
+    visitor: {
+      Program(path: NodePath<t.Program>) {
+        // import { withBugpilot } from '@bugpilot/plugin-nextjs'
+        const importPlugin = t.importDeclaration(
+          [
+            t.importSpecifier(
+              t.identifier("withBugpilot"),
+              t.identifier("withBugpilot"),
+            ),
+          ],
+          t.stringLiteral("@bugpilot/plugin-nextjs"),
+        );
+        path.node.body.unshift(importPlugin);
+
+        const importConfig = t.importDeclaration(
+          [
+            t.importSpecifier(
+              t.identifier("bugpilotConfig"),
+              t.identifier("default"),
+            ),
+          ],
+          t.stringLiteral("./bugpilot.config.js"),
+        );
+        path.node.body.unshift(importConfig);
+      },
+
+      ExportDefaultDeclaration(path: NodePath<t.ExportDefaultDeclaration>) {
+        if (
+          t.isClassDeclaration(path.node.declaration) ||
+          t.isTSDeclareFunction(path.node.declaration)
+        ) {
+          throw new Error(
+            "Invalid export type from Next.js config file:" +
+              path.node.declaration.type,
+          );
+        }
+
+        if (t.isAssignmentExpression(path.node.declaration)) {
+          // Very weird but still valid syntax:
+          // export default nextConfig = {
+          //   reactStrictMode: true,
+          //   images: {
+          //     domains: ["localhost"],
+          //   },
+          // };
+          throw new Error(
+            "Unsupported export syntax of type " +
+              path.node.declaration.type +
+              ". Do you really mean to export an assignment (" +
+              path.node.declaration.left +
+              " = ...)?",
+          );
+        }
+
+        // Replace the default export with wrapped code
+        path.replaceWith(
+          t.exportDefaultDeclaration(
+            t.callExpression(t.identifier("withBugpilot"), [
+              t.toExpression(path.node.declaration),
+              t.identifier("bugpilotConfig"),
+            ]),
+          ),
+        );
+
+        path.skip();
       },
     },
   };

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -26,9 +26,14 @@ export async function run(opts: Opts) {
   log.info("Running from directory: " + rootDir);
 
   log.step("Checking prerequisites...");
-  const configFilename = getNextJsConfigFilename();
   ensureNextJsVersion();
   const appFolder = getAppFolder(rootDir);
+
+  let configFilename = getNextJsConfigFilename();
+
+  if (configFilename === null) {
+    configFilename = createEmptyNextJsConfig(rootDir);
+  }
 
   log.step(`Updating ${path.relative(process.cwd(), configFilename)}...`);
   injectConfig(configFilename);
@@ -48,6 +53,21 @@ export async function run(opts: Opts) {
   log.success(
     "Next.js App Router wizard completed. It's a good idea to commit your changes now.",
   );
+}
+
+function createEmptyNextJsConfig(rootDir: string) {
+  const configFilePath = join(rootDir, "next.config.mjs");
+
+  log.warning(
+    `Could not find next.config.js or next.config.mjs. Are you running this command from your project root folder? A default empty next.config.mjs file will be created.`,
+  );
+
+  writeFileSync(
+    configFilePath,
+    "/** @type {import('next').NextConfig} */\n\nconst nextConfig = {};\n\nexport default nextConfig;\n",
+  );
+
+  return configFilePath;
 }
 
 function getAppFolder(rootDir: string) {


### PR DESCRIPTION
This PR closes https://github.com/bugpilot/plugin-nextjs/issues/8, adding support for `next.config.mjs` (`export default`...).
Additionally, if the (optional) next config file is not found, an empty one is created.