### PR TITLE
import babel plugins instead of using string references

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugpilot/wizard",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Bugpilot Wizard is a CLI tool to help you setup Bugpilot in your project",
   "repository": {
     "type": "git",

--- a/src/babel.d.ts
+++ b/src/babel.d.ts
@@ -1,0 +1,8 @@
+declare module "@babel/plugin-syntax-jsx" {
+  const plugin: unknown;
+  export default plugin;
+}
+declare module "@babel/plugin-syntax-typescript" {
+  const plugin: unknown;
+  export default plugin;
+}

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -3,6 +3,8 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import path, { join } from "node:path";
 
 import { transformSync } from "@babel/core";
+import pluginSyntaxJsx from "@babel/plugin-syntax-jsx";
+import pluginSyntaxTypescript from "@babel/plugin-syntax-typescript";
 import { log } from "@clack/prompts";
 import chalk from "chalk";
 
@@ -132,12 +134,12 @@ function addBugpilotToLayout(appFolder: string, workspaceId: string) {
   const result = transformSync(originalCode, {
     plugins: [
       [
-        "@babel/plugin-syntax-typescript",
+        pluginSyntaxTypescript,
         {
           isTSX: true,
         },
       ],
-      "@babel/plugin-syntax-jsx",
+      [pluginSyntaxJsx, {}],
       addRootTagFactory(workspaceId),
     ],
   });


### PR DESCRIPTION
This should make the wizard work with `npx` as well.